### PR TITLE
Update LDAP Filter

### DIFF
--- a/ADFSDump/AD.cs
+++ b/ADFSDump/AD.cs
@@ -8,7 +8,7 @@ namespace ADFSDump.ActiveDirectory
 {
     public static class ADSearcher
     {
-        private const string LdapFilter = "(&(objectClass=contact)(!(cn=CryptoPolicy)))";
+        private const string LdapFilter = "(&(thumbnailphoto=*)(objectClass=contact)(!(cn=CryptoPolicy)))";
 
         public static void GetPrivKey(Dictionary<string,string> arguments)
         {


### PR DESCRIPTION
Updated the LDAP filter to only return objects that have a `thumbnailphoto` property with any value. I was recently in an environment where the built-in search base returned multiple objects. The for loop over the `mySearcher.FindAll()` results errors out and doesn't recover because the first returned object did not have a `thumbnailphoto` property.