### PR TITLE
Modified to allow username/password arguments when querying AD for private key 

### DIFF
--- a/ADFSDump/AD.cs
+++ b/ADFSDump/AD.cs
@@ -12,14 +12,32 @@ namespace ADFSDump.ActiveDirectory
 
         public static void GetPrivKey(Dictionary<string,string> arguments)
         {
+            string username = "";
+            string password = "";
             string domain = "";
             string server = "";
             string searchString = "";
+            bool runAsUser = false;
+
             if(!arguments.ContainsKey("/domain"))
             {
                 //no domain or server given, try to find it ourselves
                 domain = System.DirectoryServices.ActiveDirectory.Domain.GetCurrentDomain().Name;
                 searchString = "LDAP://";
+            }
+            if(arguments.ContainsKey("/username"))
+            {
+                if(arguments.ContainsKey("/password"))
+                {
+                    username = arguments["/username"];
+                    password = arguments["/password"];
+                    runAsUser = true;
+                }
+                else
+                {
+                    Console.WriteLine("[!] If you provide a username, you must provide a password!");
+                    Environment.Exit(0);
+                }
             }
             else
             {
@@ -50,19 +68,24 @@ namespace ADFSDump.ActiveDirectory
 
             try
             {
-                using (DirectoryEntry entry = new DirectoryEntry(ldap))
+                DirectoryEntry entry = new DirectoryEntry();
+                if (runAsUser)
                 {
-                    using (DirectorySearcher mySearcher = new DirectorySearcher(entry))
+                     entry = new DirectoryEntry(ldap, username, password);
+                }
+                else
+                {
+                     entry = new DirectoryEntry(ldap);
+                }
+                using (DirectorySearcher mySearcher = new DirectorySearcher(entry))
+                {
+                    mySearcher.Filter = (LdapFilter);
+                    mySearcher.PropertiesToLoad.Add("thumbnailphoto");
+                    foreach (SearchResult resEnt in mySearcher.FindAll())
                     {
-                        mySearcher.Filter = (LdapFilter);
-                        mySearcher.PropertiesToLoad.Add("thumbnailphoto");
-                        foreach (SearchResult resEnt in mySearcher.FindAll())
-                        {
-                            byte[] privateKey = (byte[])resEnt.Properties["thumbnailphoto"][0];
-                            string convertedPrivateKey = BitConverter.ToString(privateKey);
-                            Console.WriteLine("[-] Private Key: {0}\r\n\r\n", convertedPrivateKey);
-                        }
-
+                        byte[] privateKey = (byte[])resEnt.Properties["thumbnailphoto"][0];
+                        string convertedPrivateKey = BitConverter.ToString(privateKey);
+                        Console.WriteLine("[-] Private Key: {0}\r\n\r\n", convertedPrivateKey);
                     }
                 }
             }

--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ ADFSDump is a tool that will read information from Active Directory and from the
 * `/server:`: The Domain Controller to target. Defaults to the current DC.
 * `/nokey`: Switch. Toggle to disable outputting the DKM key.
 * `/database`:  (optional) SQL connection string if ADFS is using remote MS SQL rather than WID. Wrap in quotes, i.e. "/database:Data Source=sql.domain.com;Initial Catalog=AdfsConfigurationV4;Integrated Security=True"
+* `/username`: (optional) Username to run the tool as. If set, must have a password passed with it.
+* `/password`: (optional) Password for the user account to run the tool as.
 
-## Compilation Instrucrtions
+## Compilation Instructions
 
 A compiled version will not be released. You'll have to compile it yourself!
 


### PR DESCRIPTION
Subtle changes were made to the code to allow an option to pass the ADFS username and password on the command line at runtime. 

I needed this when facing a double-hop issue, as I couldn't query the DC from my current context. Adding the credentials to the LDAP search solved this.