### PR TITLE
Use the declarated variable e

### DIFF
--- a/ADFSDump/Program.cs
+++ b/ADFSDump/Program.cs
@@ -30,6 +30,7 @@ namespace ADFSDump
             } catch (Exception e)
             {
                Info.ShowHelp();
+               Console.WriteLine(e);
                Environment.Exit(1);
             }
             return arguments;


### PR DESCRIPTION
Hi ! 
The variable 'u' is declared but never used in the file Program.cs (line 30), which makes the project uncompilable without modifying it : 

```bash
user@kali:~$ csb ADFSDump
[+] Found tool ADFSDump at https://github.com/mandiant/ADFSDump
[+] Cloning in ADFSDump
Cloning into 'ADFSDump'...
remote: Enumerating objects: 105, done.
remote: Counting objects: 100% (20/20), done.
remote: Compressing objects: 100% (16/16), done.
remote: Total 105 (delta 6), reused 10 (delta 4), pack-reused 85 (from 1)
Receiving objects: 100% (105/105), 33.48 KiB | 1.86 MiB/s, done.
Resolving deltas: 100% (55/55), done.
[+] Found ./ADFSDump.sln, attempting build...
[+] Running nuget restore for packages
[+] NuGet restore successful
Microsoft (R) Build Engine version 16.10.1 for Mono
Copyright (C) Microsoft Corporation. All rights reserved.

/data/ADFSDump/ADFSDump/Program.cs(30,32): warning CS0168: The variable 'e' is declared but never used [/data/ADFSDump/ADFSDump/ADFSDump.csproj]
[+] Compilation successful
```

In this example, i'm using [https://github.com/dreamkinn/CompileCSDocker](https://github.com/dreamkinn/CompileCSDocker) to compile it from a linux machine. 

Regards,
Fufu